### PR TITLE
[수정] 행사 시작일, 종료일 출력형식 변경 #16

### DIFF
--- a/events/serializers.py
+++ b/events/serializers.py
@@ -43,8 +43,8 @@ class EventSerializer(serializers.ModelSerializer):
 
     created_at = serializers.DateTimeField(format="%m월%d일 %H:%M", read_only=True)
     updated_at = serializers.DateTimeField(format="%m월%d일 %H:%M", read_only=True)
-    event_start_date = serializers.DateTimeField(format="%m월%d일 %H:%M", read_only=True)
-    event_end_date = serializers.DateTimeField(format="%m월%d일 %H:%M", read_only=True)
+    event_start_date = serializers.DateTimeField(read_only=True)
+    event_end_date = serializers.DateTimeField(read_only=True)
     review_count = serializers.SerializerMethodField()
 
     likes_count = serializers.SerializerMethodField()


### PR DESCRIPTION
events/serializers.py : event_start_date , event_end_date의 출력형식을 연도포함 형식으로 변경