### PR TITLE
[추가] 한복점 카테고리를 위한  태그잇 추가 #8 #9

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -45,6 +45,8 @@ INSTALLED_APPS = [
     "rest_framework",
     "rest_framework_simplejwt",
     "django_filters",
+    "taggit.apps.TaggitAppConfig",
+    "taggit_templatetags2",
     "events",
     "stores",
     "users",
@@ -198,3 +200,8 @@ ACCOUNT_EMAIL_REQUIRED = True
 ACCOUNT_UNIQUE_EMAIL = True
 ACCOUNT_USER_MODEL_USERNAME_FIELD = None
 ACCOUNT_USERNAME_REQUIRED = False
+
+
+# taggit
+TAGGIT_CASE_INSENSITIVE = True
+TAGGIT_LIMIT = 50

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,14 +11,16 @@ dj-rest-auth==4.0.1
 Django==4.2.2
 django-allauth==0.54.0
 django-cors-headers==4.0.0
+django-crontab==0.7.1
 django-environ==0.10.0
 django-filter==23.2
+django-taggit==4.0.0
 djangorestframework==3.14.0
 djangorestframework-simplejwt==5.2.2
 idna==3.4
 oauthlib==3.2.2
 Pillow==9.5.0
-psycopg2==2.9.6
+psycopg2-binary==2.9.6
 pycparser==2.21
 PyJWT==2.7.0
 python-dotenv==1.0.0

--- a/stores/models.py
+++ b/stores/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from taggit.managers import TaggableManager
 from users.models import User
 from django.core.validators import MaxValueValidator, MinValueValidator
 
@@ -17,6 +18,7 @@ class Store(models.Model):
     store_bookmarks = models.ManyToManyField(
         User, related_name="bookmark_stores", blank=True
     )
+    tags = TaggableManager(blank=True)
 
     def __str__(self):
         return self.store_name

--- a/stores/serializers.py
+++ b/stores/serializers.py
@@ -4,6 +4,7 @@ import requests, json
 import os
 import environ
 from django.db.models import Avg
+from taggit.serializers import TagListSerializerField, TaggitSerializer
 
 
 # ✅ 위치정보 api
@@ -19,10 +20,11 @@ def get_location(address):
 
 
 # ✅ 한복집 리스트 (id, 판매자, 가게이름, 가게주소, x좌표, y좌표, 전체 좋아요 수, 평균 별점, 북마크)
-class StoreListSerializer(serializers.ModelSerializer):
+class StoreListSerializer(TaggitSerializer, serializers.ModelSerializer):
     owner = serializers.SerializerMethodField()
     total_likes = serializers.SerializerMethodField()
     avg_stars = serializers.SerializerMethodField()
+    tags = TagListSerializerField()
 
     def get_owner(self, obj):
         return obj.owner.id
@@ -48,16 +50,20 @@ class StoreListSerializer(serializers.ModelSerializer):
             "total_likes",
             "avg_stars",
             "store_bookmarks",
+            "tags",
         )
 
 
 # ✅ 한복집 추가 (가게이름, 가게주소)
-class CreateStoreSerializer(serializers.ModelSerializer):
+class CreateStoreSerializer(TaggitSerializer, serializers.ModelSerializer):
+    tags = TagListSerializerField()
+
     class Meta:
         model = Store
         fields = (
             "store_name",
             "store_address",
+            "tags",
         )
 
     # ✅ 한복집 x,y좌표 | 별점(후기없는경우 0) 추가


### PR DESCRIPTION
23.06.29

config/settings.py : installed app에 추가
requirements.txt : 태그잇 추가
stores/models.py : 한복점 태그 필드 추가
stores/serializers.py : 한복점 리스트에 태그 필드추가