### PR TITLE
[수정] 카카오로그인 #5 // 유저네임 유지

### DIFF
--- a/users/views.py
+++ b/users/views.py
@@ -168,10 +168,10 @@ class KakaoCallbackView(APIView):
 
         try:
             user = User.objects.get(email=email)
-            user.username = username
-            user.save()
             refresh = RefreshToken.for_user(user)
             refresh["email"] = user.email
+            refresh["username"] = user.username
+            user.save()
             return Response(
                 {
                     "refresh": str(refresh),
@@ -185,11 +185,11 @@ class KakaoCallbackView(APIView):
             user = User.objects.create_user(
                 email=email, password=password, username=username
             )
-            user.username = username
             user.set_unusable_password()
             user.save()
             refresh = RefreshToken.for_user(user)
             refresh["email"] = user.email
+            refresh["username"] = user.username
             return Response(
                 {
                     "refresh": str(refresh),


### PR DESCRIPTION
- 카카오 로그인: 로그인 할 때 마다 유저네임 새로 생성되는 이슈 
- 유저네임 생성이 아니라 refresh로 전에 있던 정보 받아오는걸로 수정. 